### PR TITLE
Rename OrdenarListaPorPontos implementation

### DIFF
--- a/src/main/java/br/com/mavidsmile/mavidsmile/usecases/impl/OrdenarListaPorPontosImpl.java
+++ b/src/main/java/br/com/mavidsmile/mavidsmile/usecases/impl/OrdenarListaPorPontosImpl.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-public class OrdernarListaPorPontos implements OrdenarListaPorPontos {
+public class OrdenarListaPorPontosImpl implements OrdenarListaPorPontos {
     @Override
     public List<ClienteRankingResponseDTO> executa(List<ClienteRankingResponseDTO> rankingDeClientes) {
         rankingDeClientes = rankingDeClientes.stream()


### PR DESCRIPTION
## Summary
- rename the use case impl file to `OrdenarListaPorPontosImpl.java`
- update the class declaration to match the new name

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f646cdc10832090532e7cc51b7205